### PR TITLE
apt_repo_docker: Use deb822_repository module

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -21,17 +21,16 @@ name: CI
   # Run CI once per day (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test for each ansible-base version
   schedule:
-    - cron: '0 6 * * *'
+    - cron: "0 6 * * *"
 env:
   NAMESPACE: mgit_at
   COLLECTION_NAME: roles
 
 jobs:
-
-###
-# Sanity tests (REQUIRED)
-#
-# https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
+  ###
+  # Sanity tests (REQUIRED)
+  #
+  # https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
 
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }})
@@ -60,9 +59,9 @@ jobs:
           #   ansible.netcommon
           #   ansible.utils
 
-###
-# pre-commit tests (using the pre-commit tool)
-#
+  ###
+  # pre-commit tests (using the pre-commit tool)
+  #
 
   pre-commit:
     runs-on: ubuntu-latest
@@ -87,7 +86,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install pre-commit
         run: pip install pre-commit
@@ -157,7 +156,6 @@ jobs:
 # Integration tests (RECOMMENDED)
 #
 # https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html
-
 
 # If the application you are testing is available as a docker container and you want to test
 # multiple versions see the following for an example:

--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -10,7 +10,7 @@ name: Lint extra docsite docs and links
   # Run CI once per day (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test for each ansible-base version
   schedule:
-    - cron: '0 6 * * *'
+    - cron: "0 6 * * *"
 
 jobs:
   docsite:
@@ -19,14 +19,13 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out code
         uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install antsibull-docs
         run: pip install antsibull-docs --disable-pip-version-check

--- a/.github/workflows/molecule-test.yml
+++ b/.github/workflows/molecule-test.yml
@@ -10,7 +10,7 @@ name: Molecule CI
   # Run CI on Monday (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still testing against latest changes/packages upstream
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: "0 6 * * 1"
 env:
   NAMESPACE: mgit_at
   COLLECTION_NAME: roles
@@ -21,10 +21,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-
-###
-# pre-commit tests (using the pre-commit tool)
-#
+  ###
+  # pre-commit tests (using the pre-commit tool)
+  #
 
   pre-commit-molecule:
     runs-on: ubuntu-latest
@@ -56,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   ## Manual checks (these are not fast or specific enough to be run on every commit)
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v6.17.1
+    rev: v6.17.2
     hooks:
       - id: ansible-lint
         name: Lint the repository with ansible-lint

--- a/roles/apt_repo_docker/molecule/default/verify.yml
+++ b/roles/apt_repo_docker/molecule/default/verify.yml
@@ -19,7 +19,7 @@
           and ansible_distribution_major_version | int <= 20)
     - name: Grep all deb entries in /etc/apt for repo (deb822)
       # https://askubuntu.com/questions/148932/how-can-i-get-a-list-of-all-repositories-and-ppas-from-the-command-line-into-an
-      ansible.builtin.command: grep -r --include '*.sources' ' deb$' /etc/apt/sources.list.d/
+      ansible.builtin.command: grep -r -A 3 --include '*.sources' ' deb$' /etc/apt/sources.list.d/
       register: deb822_entries
       changed_when: false # idempotent
       failed_when: "'https://download.docker.com/linux/' not in deb822_entries['stdout']"

--- a/roles/apt_repo_docker/molecule/default/verify.yml
+++ b/roles/apt_repo_docker/molecule/default/verify.yml
@@ -6,12 +6,29 @@
     - name: Apt update should work without errors
       ansible.builtin.apt:
         update_cache: true
-    - name: Grep all deb entries in /etc/apt for repo
+    - name: Grep all deb entries in /etc/apt for repo (old)
       # https://askubuntu.com/questions/148932/how-can-i-get-a-list-of-all-repositories-and-ppas-from-the-command-line-into-an
       ansible.builtin.command: grep -r --include '*.list' '^deb ' /etc/apt/sources.list /etc/apt/sources.list.d/
       register: deb_entries
       changed_when: false # idempotent
       failed_when: "'https://download.docker.com/linux/' not in deb_entries['stdout']"
+      when:
+        # deb822_repository module was added in 2.15
+        - ansible_version['major'] == 2
+        - ansible_version['minor'] <= 14 or (ansible_distribution == "Debian" and ansible_distribution_major_version | int <= 11) or (ansible_distribution == "Ubuntu"
+          and ansible_distribution_major_version | int <= 20)
+    - name: Grep all deb entries in /etc/apt for repo (deb822)
+      # https://askubuntu.com/questions/148932/how-can-i-get-a-list-of-all-repositories-and-ppas-from-the-command-line-into-an
+      ansible.builtin.command: grep -r --include '*.sources' ' deb$' /etc/apt/sources.list.d/
+      register: deb822_entries
+      changed_when: false # idempotent
+      failed_when: "'https://download.docker.com/linux/' not in deb822_entries['stdout']"
+      when:
+        # deb822_repository module was added in 2.15
+        - ansible_version['major'] == 2
+        - ansible_version['minor'] >= 15
+        - (ansible_distribution == "Debian" and ansible_distribution_major_version | int >= 12) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version
+          | int >= 22)
     - name: Containerd.io should be installable
       ansible.builtin.apt:
         name:

--- a/roles/apt_repo_docker/tasks/main.yml
+++ b/roles/apt_repo_docker/tasks/main.yml
@@ -37,7 +37,7 @@
     name: docker
     types: deb
     uris:
-      - "https://download.docker.com/linux/{{ ansible_distribution | lower }}"
+      - https://download.docker.com/linux/{{ ansible_distribution | lower }}
     suites:
       - "{{ ansible_distribution_release }}"
     components:
@@ -46,6 +46,7 @@
     # Explicitly stored here instad of referring to an URL
     signed_by: |-
       -----BEGIN PGP PUBLIC KEY BLOCK-----
+
       mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
       lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
       38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
@@ -117,7 +118,7 @@
     name: docker
     types: deb
     uris:
-      - "https://download.docker.com/linux/{{ ansible_distribution | lower }}"
+      - https://download.docker.com/linux/{{ ansible_distribution | lower }}
     suites:
       - "{{ ansible_distribution_release }}"
     components:
@@ -127,6 +128,7 @@
     # Debian and Ubuntu keys are identical at the moment by the way, but this might change(?)
     signed_by: |-
       -----BEGIN PGP PUBLIC KEY BLOCK-----
+
       mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
       lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
       38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq

--- a/roles/apt_repo_docker/tasks/main.yml
+++ b/roles/apt_repo_docker/tasks/main.yml
@@ -4,8 +4,8 @@
   when:
     # deb822_repository module was added in 2.15
     - ansible_version['major'] == 2
-    - ansible_version['minor'] <= 14 or (ansible_distribution == "Debian" and ansible_distribution_major_version | int < 11) or (ansible_distribution == "Ubuntu"
-      and ansible_distribution_major_version | int < 22)
+    - ansible_version['minor'] <= 14 or (ansible_distribution == "Debian" and ansible_distribution_major_version | int <= 11) or (ansible_distribution == "Ubuntu"
+      and ansible_distribution_major_version | int <= 20)
   block:
     - name: Install docker repo key on debian hosts
       when: ansible_distribution == "Debian"
@@ -114,7 +114,7 @@
     - ansible_version['minor'] >= 15
     - ansible_distribution == "Debian"
     # Debian 12 and above
-    - ansible_distribution_major_version | int > 11
+    - ansible_distribution_major_version | int >= 12
 
 - name: Install using deb822_repository on ubuntu hosts
   ansible.builtin.deb822_repository:
@@ -198,7 +198,7 @@
     - ansible_version['minor'] >= 15
     - ansible_distribution == "Ubuntu"
     # Ubuntu 22.04 and above
-    - ansible_distribution_major_version | int > 22
+    - ansible_distribution_major_version | int >= 22
 
 - name: Run handlers to update apt cache
   ansible.builtin.meta: flush_handlers

--- a/roles/apt_repo_docker/tasks/main.yml
+++ b/roles/apt_repo_docker/tasks/main.yml
@@ -4,7 +4,8 @@
   when:
     # deb822_repository module was added in 2.15
     - ansible_version['major'] == 2
-    - ansible_version['minor'] <= 14
+    - ansible_version['minor'] <= 14 or (ansible_distribution == "Debian" and ansible_distribution_major_version | int < 11) or (ansible_distribution == "Ubuntu"
+      and ansible_distribution_major_version | int < 22)
   block:
     - name: Install docker repo key on debian hosts
       when: ansible_distribution == "Debian"
@@ -112,6 +113,8 @@
     - ansible_version['major'] >= 2
     - ansible_version['minor'] >= 15
     - ansible_distribution == "Debian"
+    # Debian 12 and above
+    - ansible_distribution_major_version | int > 11
 
 - name: Install using deb822_repository on ubuntu hosts
   ansible.builtin.deb822_repository:
@@ -194,6 +197,8 @@
     - ansible_version['major'] >= 2
     - ansible_version['minor'] >= 15
     - ansible_distribution == "Ubuntu"
+    # Ubuntu 22.04 and above
+    - ansible_distribution_major_version | int > 22
 
 - name: Run handlers to update apt cache
   ansible.builtin.meta: flush_handlers

--- a/roles/apt_repo_docker/tasks/main.yml
+++ b/roles/apt_repo_docker/tasks/main.yml
@@ -44,7 +44,7 @@
       - stable
     # Source: https://download.docker.com/linux/debian/gpg
     # Explicitly stored here instad of referring to an URL
-    signed_by: |
+    signed_by: |-
       -----BEGIN PGP PUBLIC KEY BLOCK-----
       mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
       lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
@@ -125,7 +125,7 @@
     # Source: https://download.docker.com/linux/ubuntu/gpg
     # Explicitly stored here instad of referring to an URL
     # Debian and Ubuntu keys are identical at the moment by the way, but this might change(?)
-    signed_by: |
+    signed_by: |-
       -----BEGIN PGP PUBLIC KEY BLOCK-----
       mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
       lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh

--- a/roles/apt_repo_docker/tasks/main.yml
+++ b/roles/apt_repo_docker/tasks/main.yml
@@ -1,29 +1,197 @@
 ---
-- name: Install docker repo key on debian hosts
-  when: ansible_distribution == "Debian"
-  ansible.builtin.copy:
+- name: Install apt repo using legacy method
+  # TODO: clean up legacy method when deb822 version is used
+  when:
+    # deb822_repository module was added in 2.15
+    - ansible_version['major'] == 2
+    - ansible_version['minor'] <= 14
+  block:
+    - name: Install docker repo key on debian hosts
+      when: ansible_distribution == "Debian"
+      ansible.builtin.copy:
+        # Source: https://download.docker.com/linux/debian/gpg
+        # converted using `gpg --dearmor docker.gpg`
+        src: docker_debian.gpg
+        dest: /etc/apt/trusted.gpg.d/docker.gpg
+      notify: Update apt cache
+
+    - name: Install docker repo key on ubuntu hosts
+      when: ansible_distribution == "Ubuntu"
+      ansible.builtin.copy:
+        # Source: https://download.docker.com/linux/ubuntu/gpg
+        # converted using `gpg --dearmor docker.gpg`
+        # Debian and Ubuntu keys are identical at the moment by the way, but this might change(?)
+        src: docker_ubuntu.gpg
+        dest: /etc/apt/trusted.gpg.d/docker.gpg
+      notify: Update apt cache
+
+    - name: Add docker apt repo
+      ansible.builtin.copy:
+        content: |
+          deb {{ docker_apt_repo_base_url }} {{ ansible_distribution_release }} stable
+        dest: /etc/apt/sources.list.d/docker.list
+      notify: Update apt cache
+
+- name: Install using deb822_repository on debian hosts
+  ansible.builtin.deb822_repository:
+    name: docker
+    types: deb
+    uris:
+      - "https://download.docker.com/linux/{{ ansible_distribution | lower }}"
+    suites:
+      - "{{ ansible_distribution_release }}"
+    components:
+      - stable
     # Source: https://download.docker.com/linux/debian/gpg
-    # converted using `gpg --dearmor docker.gpg`
-    src: docker_debian.gpg
-    dest: /etc/apt/trusted.gpg.d/docker.gpg
+    # Explicitly stored here instad of referring to an URL
+    signed_by: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
+      lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
+      38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
+      L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
+      UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
+      cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
+      ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
+      vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
+      G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
+      XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
+      q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
+      tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
+      BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
+      v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
+      tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
+      jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
+      6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
+      XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
+      FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
+      g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
+      ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
+      9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
+      G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
+      FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
+      EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
+      M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
+      Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
+      w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
+      z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
+      eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
+      VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
+      1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
+      zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
+      pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
+      ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
+      BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
+      1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
+      YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
+      mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
+      KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
+      JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
+      cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
+      6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
+      U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
+      VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
+      irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
+      SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
+      QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
+      9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
+      24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
+      dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
+      Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
+      H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
+      /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
+      M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
+      xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
+      jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
+      YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
+      =0YYh
+      -----END PGP PUBLIC KEY BLOCK-----
   notify: Update apt cache
+  when:
+    - ansible_version['major'] >= 2
+    - ansible_version['minor'] >= 15
+    - ansible_distribution == "Debian"
 
-- name: Install docker repo key on ubuntu hosts
-  when: ansible_distribution == "Ubuntu"
-  ansible.builtin.copy:
+- name: Install using deb822_repository on ubuntu hosts
+  ansible.builtin.deb822_repository:
+    name: docker
+    types: deb
+    uris:
+      - "https://download.docker.com/linux/{{ ansible_distribution | lower }}"
+    suites:
+      - "{{ ansible_distribution_release }}"
+    components:
+      - stable
     # Source: https://download.docker.com/linux/ubuntu/gpg
-    # converted using `gpg --dearmor docker.gpg`
+    # Explicitly stored here instad of referring to an URL
     # Debian and Ubuntu keys are identical at the moment by the way, but this might change(?)
-    src: docker_ubuntu.gpg
-    dest: /etc/apt/trusted.gpg.d/docker.gpg
+    signed_by: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
+      lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
+      38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
+      L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
+      UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
+      cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
+      ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
+      vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
+      G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
+      XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
+      q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
+      tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
+      BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
+      v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
+      tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
+      jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
+      6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
+      XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
+      FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
+      g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
+      ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
+      9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
+      G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
+      FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
+      EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
+      M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
+      Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
+      w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
+      z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
+      eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
+      VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
+      1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
+      zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
+      pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
+      ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
+      BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
+      1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
+      YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
+      mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
+      KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
+      JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
+      cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
+      6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
+      U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
+      VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
+      irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
+      SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
+      QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
+      9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
+      24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
+      dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
+      Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
+      H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
+      /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
+      M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
+      xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
+      jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
+      YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
+      =0YYh
+      -----END PGP PUBLIC KEY BLOCK-----
   notify: Update apt cache
-
-- name: Add docker apt repo
-  ansible.builtin.copy:
-    content: |
-      deb {{ docker_apt_repo_base_url }} {{ ansible_distribution_release }} stable
-    dest: /etc/apt/sources.list.d/docker.list
-  notify: Update apt cache
+  when:
+    - ansible_version['major'] >= 2
+    - ansible_version['minor'] >= 15
+    - ansible_distribution == "Ubuntu"
 
 - name: Run handlers to update apt cache
   ansible.builtin.meta: flush_handlers

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -184,8 +184,8 @@
     owner: root
     group: root
     mode: "0644"
-  with_items: "{{ modules_blacklist.net | union(modules_blacklist.fs) | union(modules_blacklist.misc) | union(modules_blacklist_host) | union(modules_blacklist_group)\
-    \ }}"
+  with_items: "{{ modules_blacklist.net | union(modules_blacklist.fs) | union(modules_blacklist.misc) | union(modules_blacklist_host) | union(modules_blacklist_group)
+    }}"
 
 ## cron
 - name: Allow cron and at for root-only

--- a/roles/kubeadm_controlplane/tasks/initial-control-plane-node.yml
+++ b/roles/kubeadm_controlplane/tasks/initial-control-plane-node.yml
@@ -110,8 +110,8 @@
 
 - name: Set variables needed by kubernetes/nodes to join the cluster on all cluster nodes
   ansible.builtin.set_fact:
-    kube_bootstrap_token: "{% if kubeadm_token_generate.stdout is defined %}{{ kubeadm_token_generate.stdout }}{% elif kubeadm_token_create.stdout is defined %}{{\
-      \ kubeadm_token_create.stdout }}{% endif %}"
+    kube_bootstrap_token: "{% if kubeadm_token_generate.stdout is defined %}{{ kubeadm_token_generate.stdout }}{% elif kubeadm_token_create.stdout is defined %}{{
+      kubeadm_token_create.stdout }}{% endif %}"
     kube_bootstrap_ca_cert_hash: sha256:{{ kube_ca_openssl.stdout }}
   delegate_to: "{{ item }}"
   delegate_facts: true

--- a/roles/kubeadm_controlplane/tasks/main.yml
+++ b/roles/kubeadm_controlplane/tasks/main.yml
@@ -71,8 +71,8 @@
 
 - name: Check if control plane nodes are tainted (2/2)
   ansible.builtin.set_fact:
-    kube_node_taints: "{% set node_info = kubectl_get_node.stdout | from_json %}{%if node_info.spec.taints is defined %}{{ node_info.spec.taints | map(attribute='key')\
-      \ | list }}{% endif %}"
+    kube_node_taints: "{% set node_info = kubectl_get_node.stdout | from_json %}{%if node_info.spec.taints is defined %}{{ node_info.spec.taints | map(attribute='key')
+      | list }}{% endif %}"
 
 # TODO: Move to kubernetes.core.k8s_taint module
 - name: Remove NoSchedule taint from control plane nodes


### PR DESCRIPTION
Time to try out the new goodness.

Will only automatically be tested in CI once 2.15 releases. Still needs potentially some cleanup tasks for converting to this slightly different way of laying out the sources.list files.