### PR TITLE
base/apt: set apt_repo_zone to internet per default

### DIFF
--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -19,7 +19,7 @@ base_ubuntu_linux_hwe: false
 base_install_ethtool_setringmax: true
 # base_cpu_governor: performance
 
-base_apt_repo_zone: "{{ apt_repo_zone }}"
+base_apt_repo_zone: "{{ apt_repo_zone | default('internet') }}"
 
 base_apt_repo_debian_components:
   - main

--- a/roles/base/templates/internet-debian.list.j2
+++ b/roles/base/templates/internet-debian.list.j2
@@ -1,0 +1,9 @@
+# debian mirrors
+deb https://deb.debian.org/debian {{ ansible_distribution_release }} {{ base_apt_repo_debian_components | join (' ') }}
+deb https://deb.debian.org/debian {{ ansible_distribution_release }}-updates {{ base_apt_repo_debian_components | join (' ') }}
+deb https://deb.debian.org/debian-security {{ ansible_distribution_release }}-security {{ base_apt_repo_debian_components | join (' ') }}
+{% if ansible_distribution_major_version >= 11 %} {# bullseye #}
+deb https://deb.debian.org/debian-security {{ ansible_distribution_release }}-security {{ base_apt_repo_debian_components | join (' ') }}
+{% else %}
+deb https://deb.debian.org/debian-security {{ ansible_distribution_release }}/updates {{ base_apt_repo_debian_components | join (' ') }}
+{% endif %}

--- a/roles/base/templates/internet-ubuntu.list.j2
+++ b/roles/base/templates/internet-ubuntu.list.j2
@@ -1,0 +1,3 @@
+deb https://mirrors.ubuntu.com/mirrors.txt {{ ansible_distribution_release }} {{ base_apt_repo_ubuntu_components | join (' ') }}
+deb https://mirrors.ubuntu.com/mirrors.txt {{ ansible_distribution_release }}-updates {{ base_apt_repo_ubuntu_components | join (' ') }}
+deb https://mirrors.ubuntu.com/mirrors.txt {{ ansible_distribution_release }}-security {{ base_apt_repo_ubuntu_components | join (' ') }}


### PR DESCRIPTION
add default internet mirrors for debian/ubuntu

ultimately to make base role usable without setting any variables (which are not required in this case), so imho would be nice