### PR TITLE
applied_role: init

### DIFF
--- a/roles/applied_role/tasks/main.yml
+++ b/roles/applied_role/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Print parent role name
+  ansible.builtin.debug:
+    var: ansible_parent_role_names
+
+- name: Create textcollector directories
+  ansible.builtin.file:
+    name: /etc/prometheus-node-exporter/textfile-collector/
+    mode: "0755"
+    state: directory
+
+- name: Create applied role prom file
+  ansible.builtin.template:
+    src: applied_role.prom.j2
+    dest: "/etc/prometheus-node-exporter/textfile-collector/{{ ansible_parent_role_names[0] | replace('/', '_') }}.prom"
+    mode: "0644"

--- a/roles/applied_role/tasks/main.yml
+++ b/roles/applied_role/tasks/main.yml
@@ -14,4 +14,6 @@
     src: applied_role.prom.j2
     dest: "/etc/prometheus-node-exporter/textfile-collector/{{ ansible_parent_role_names[0] | replace('/', '_') }}.prom"
     mode: "0644"
+  # This will never be idempotent, masking the change explicitly here
+  changed_when: false
   changed_when: false

--- a/roles/applied_role/tasks/main.yml
+++ b/roles/applied_role/tasks/main.yml
@@ -14,3 +14,4 @@
     src: applied_role.prom.j2
     dest: "/etc/prometheus-node-exporter/textfile-collector/{{ ansible_parent_role_names[0] | replace('/', '_') }}.prom"
     mode: "0644"
+  changed_when: false

--- a/roles/applied_role/tasks/main.yml
+++ b/roles/applied_role/tasks/main.yml
@@ -16,4 +16,3 @@
     mode: "0644"
   # This will never be idempotent, masking the change explicitly here
   changed_when: false
-  changed_when: false

--- a/roles/applied_role/templates/applied_role.prom.j2
+++ b/roles/applied_role/templates/applied_role.prom.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+mgit_applied_role{role="{{ ansible_parent_role_names[0] }}"} {{ ansible_date_time.epoch }}

--- a/roles/upgrade_host/tasks/main.yml
+++ b/roles/upgrade_host/tasks/main.yml
@@ -31,3 +31,7 @@
   register: upgrade_host_failed_result
   failed_when: "'failed' in upgrade_host_failed_result.stdout"
   changed_when: false # Read-only command
+- name: Include applied role
+  when: applied_role_enabled | default(false)
+  ansible.builtin.include_role:
+    name: mgit_at.roles.applied_role


### PR DESCRIPTION
Implemente the applied role to have metric, about which roles are rolled out on a host in prometheus. Those metrics are collected by the text collector of the node exporter.