### PR TITLE
fix: Make sure services are disabled and will not be restarted.

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -146,10 +146,11 @@
     - pmcd
     - pmproxy
     - pmlogger
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: "{{ item }}"
     state: stopped
     enabled: false
+    masked: true
   register: unused_disable
   failed_when: unused_disable is failed and ('find' not in unused_disable.msg and 'found' not in unused_disable.msg)
 


### PR DESCRIPTION
Since "pmcd.service" is set to "restart=always" it will be restarted if it has "state=dead"(running but was stopped) when host is rebooted.